### PR TITLE
Parallelize data fetching for faster page loads

### DIFF
--- a/src/domains/about/index.tsx
+++ b/src/domains/about/index.tsx
@@ -18,11 +18,13 @@ import { RequestHandler } from "@/components/atoms/request-handler";
 export const revalidate = 60;
 
 const AboutPage = async () => {
-    const t = await getTranslations("AboutPage");
-    const data = await getStaticPageBySlug('about');
-    const partners = await getCompanyPartners();
-    const reviews = await getPartnersReviews();
-    const promotion_types = await getPromotionTypes();
+    const [t, data, partners, reviews, promotion_types] = await Promise.all([
+        getTranslations("AboutPage"),
+        getStaticPageBySlug("about"),
+        getCompanyPartners(),
+        getPartnersReviews(),
+        getPromotionTypes(),
+    ]);
 
 
     const names = {

--- a/src/domains/blog/index.tsx
+++ b/src/domains/blog/index.tsx
@@ -12,10 +12,12 @@ import { getPromotionTypes } from "@/api/Types";
 export const revalidate = 60;
 
 const BlogPage = async () => {
-    const data = await getStaticPageBySlug('blog');
-    const t = await getTranslations("AboutPage");
-    const promotion_types = await getPromotionTypes();
-    const articles = await getArticles();
+    const [data, t, promotion_types, articles] = await Promise.all([
+        getStaticPageBySlug("blog"),
+        getTranslations("AboutPage"),
+        getPromotionTypes(),
+        getArticles(),
+    ]);
 
     const names = {
         title: t("banner.title"),

--- a/src/domains/cases/index.tsx
+++ b/src/domains/cases/index.tsx
@@ -15,16 +15,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const CasesPage = async () => {
-    const data = await getStaticPageBySlug('cases');
-    const post_data = await getPosts();
-    const t = await getTranslations("Cases");
-    const promotion_types = await getPromotionTypes();
-    
-    const [partners, reviews] =
-        await Promise.all([
-            getCompanyPartners(),
-            getPartnersReviews()
-        ]);
+    const [
+        data,
+        post_data,
+        t,
+        promotion_types,
+        partners,
+        reviews,
+    ] = await Promise.all([
+        getStaticPageBySlug("cases"),
+        getPosts(),
+        getTranslations("Cases"),
+        getPromotionTypes(),
+        getCompanyPartners(),
+        getPartnersReviews(),
+    ]);
 
     type BannerTexts = {
         title: string;

--- a/src/domains/home/index.tsx
+++ b/src/domains/home/index.tsx
@@ -28,14 +28,25 @@ const NewsBanner = dynamic(() => import("@/components/atoms/NewsBanner/NewsBanne
 export const revalidate = 60;
 
 const HomePage = async () => {
-    const t = await getTranslations("HomePage.section2");
-    const banners = await getBanners();
-    const marketingDepartmentData = await getMarketingDepartment()
-    const companyChallenges = await getCompanyChallenges()
-    const articles = await getArticles()
-    const partners = await getCompanyPartners()
-    const reviews = await getPartnersReviews()
-    const promotion_types = await getPromotionTypes();
+    const [
+        t,
+        banners,
+        marketingDepartmentData,
+        companyChallenges,
+        articles,
+        partners,
+        reviews,
+        promotion_types,
+    ] = await Promise.all([
+        getTranslations("HomePage.section2"),
+        getBanners(),
+        getMarketingDepartment(),
+        getCompanyChallenges(),
+        getArticles(),
+        getCompanyPartners(),
+        getPartnersReviews(),
+        getPromotionTypes(),
+    ]);
     
     return (
         <>

--- a/src/domains/services/branding.tsx
+++ b/src/domains/services/branding.tsx
@@ -25,13 +25,19 @@ import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
 export const revalidate = 60;
 
 const BradingPage = async () => {
-    const data = await getStaticPageBySlug('branding');
-    const t = await getTranslations("ServicePage4");
-    const t2 = await getTranslations("Buttons");
-    const [serviceData, promotion_types] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        serviceData,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("branding"),
+        getTranslations("ServicePage4"),
+        getTranslations("Buttons"),
         getCompanyFeatures(),
-        getPromotionTypes()
-    ])
+        getPromotionTypes(),
+    ]);
 
     const serviceDataStatic = {
         title: "Создаем бренд, который говорит сам за себя",

--- a/src/domains/services/context-ad.tsx
+++ b/src/domains/services/context-ad.tsx
@@ -13,14 +13,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const ContextAdsPage = async () => {
-    const data = await getStaticPageBySlug('context-ads');
-    const [t, t2, contextAdData, contextAdCardData, promotion_types] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        contextAdData,
+        contextAdCardData,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("context-ads"),
         getTranslations("ServicesPage2"),
         getTranslations("Buttons"),
         fetchContextAdData(),
         fetchContextAdCardData(),
         getPromotionTypes(),
-    ])
+    ]);
 
   
 

--- a/src/domains/services/crm.tsx
+++ b/src/domains/services/crm.tsx
@@ -17,9 +17,11 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const CrmPage = async () => {
-    const t = await getTranslations("ServicesPage7")
-    const data = await getStaticPageBySlug('crm')
-    const promotion_types = await getPromotionTypes();
+    const [t, data, promotion_types] = await Promise.all([
+        getTranslations("ServicesPage7"),
+        getStaticPageBySlug("crm"),
+        getPromotionTypes(),
+    ]);
    
     const serviceCrmData: ISmmTeamMembers = {
         title: t("BenefitsSection.title"),

--- a/src/domains/services/marketing-support.tsx
+++ b/src/domains/services/marketing-support.tsx
@@ -18,10 +18,12 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const MarketingSupportPage = async () => {
-    const data = await getStaticPageBySlug("marketing-support");
-    const t = await getTranslations("ServicesPage8");
-    const t2 = await getTranslations("Buttons");
-    const promotion_types = await getPromotionTypes();
+    const [data, t, t2, promotion_types] = await Promise.all([
+        getStaticPageBySlug("marketing-support"),
+        getTranslations("ServicesPage8"),
+        getTranslations("Buttons"),
+        getPromotionTypes(),
+    ]);
     
     const serviceData = {
         title: t("WhatWeDo.mainTitle"),

--- a/src/domains/services/operative-print.tsx
+++ b/src/domains/services/operative-print.tsx
@@ -36,10 +36,12 @@ type Designs = {
 };
 
 const PrintPage = async () => {
-    const data = await getStaticPageBySlug('operative-print');
-    const cards = await getBusinessCards();
-    const t = await getTranslations("ServicesPage9");
-    const promotion_types = await getPromotionTypes();
+    const [data, cards, t, promotion_types] = await Promise.all([
+        getStaticPageBySlug("operative-print"),
+        getBusinessCards(),
+        getTranslations("ServicesPage9"),
+        getPromotionTypes(),
+    ]);
 
     const servicePrintData: ISmmTeamMembers = {
         title: t("howWeWork.title1"),

--- a/src/domains/services/seo.tsx
+++ b/src/domains/services/seo.tsx
@@ -13,15 +13,23 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SeoPage = async () => {
-    const data = await getStaticPageBySlug('seo');
-    const [t, t2, promotion_types, seoData, seoPostsData, seoCardsData] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        promotion_types,
+        seoData,
+        seoPostsData,
+        seoCardsData,
+    ] = await Promise.all([
+        getStaticPageBySlug("seo"),
         getTranslations("ServicesPage3"),
         getTranslations("Buttons"),
         getPromotionTypes(),
         fetchSeoData(),
         fetchSeoPostsData(),
         fetchSeoCardsData(),
-    ])
+    ]);
 
     return (
         <>

--- a/src/domains/services/site-creating.tsx
+++ b/src/domains/services/site-creating.tsx
@@ -10,9 +10,11 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SiteCreatingPage = async () => {
-    const data = await getStaticPageBySlug('site-creating')
-    const promotion_types = await getPromotionTypes();
-    const t = await getTranslations("ServicePage6");
+    const [data, promotion_types, t] = await Promise.all([
+        getStaticPageBySlug("site-creating"),
+        getPromotionTypes(),
+        getTranslations("ServicePage6"),
+    ]);
 
     const serviceData = {
         title: t('Approach.title'),

--- a/src/domains/services/smm.tsx
+++ b/src/domains/services/smm.tsx
@@ -16,12 +16,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SmmPage = async () => {
-    const data = await getStaticPageBySlug('smm');
-    const ads = await getCompanyAds();
-    const t = await getTranslations("ServicesPage1");
-    const smmCreatingAdData = await fetchSmmCreatingAdData();
-    const smmTeamMembers = await fetchSmmTeamMembers();
-    const promotion_types = await getPromotionTypes();
+    const [
+        data,
+        ads,
+        t,
+        smmCreatingAdData,
+        smmTeamMembers,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("smm"),
+        getCompanyAds(),
+        getTranslations("ServicesPage1"),
+        fetchSmmCreatingAdData(),
+        fetchSmmTeamMembers(),
+        getPromotionTypes(),
+    ]);
 
     const serviceData = {
         title: t("zigzak.title"),

--- a/src/domains/services/video-production.tsx
+++ b/src/domains/services/video-production.tsx
@@ -14,10 +14,12 @@ import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
 export const revalidate = 60;
 
 const VideoProductionPage = async () => {
-    const data = await getStaticPageBySlug('video-production');
-    const videoData = await getVideoProduction();
-    const t = await getTranslations("ServicePage5");
-    const promotion_types = await getPromotionTypes();
+    const [data, videoData, t, promotion_types] = await Promise.all([
+        getStaticPageBySlug("video-production"),
+        getVideoProduction(),
+        getTranslations("ServicePage5"),
+        getPromotionTypes(),
+    ]);
 
     const serviceData = {
         title: t("Services.title"),


### PR DESCRIPTION
## Summary
- batch translations and API requests with Promise.all across home, informational, and service pages to reduce render latency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ecd1784fa0832e888af82e65284bee