### PR TITLE
Preload global app data and lazy-load video players

### DIFF
--- a/src/api/BusinessType/index.ts
+++ b/src/api/BusinessType/index.ts
@@ -24,3 +24,8 @@ export async function getBusinessCards() {
     const locale = await getLocale()
     return fetchData<ParallaxData>("/business-cards/", locale)
 }
+
+export async function getBusinessTypes(cache: RequestCache = "force-cache") {
+    const locale = await getLocale()
+    return fetchData<Type[]>("/business-types/", locale, cache)
+}

--- a/src/api/Company/index.ts
+++ b/src/api/Company/index.ts
@@ -86,6 +86,11 @@ export async function getCompanyChallenges() {
     return fetchData<CompanyChallengesResponse>("/company-challenges/", locale);
 }
 
+export async function getCompanyInfo(cache: RequestCache = "force-cache") {
+    const locale = await getLocale();
+    return fetchData<CompanyInfoResponse>("/company-info/", locale, cache);
+}
+
 export async function getCompanyAdvantages() {
     const locale = await getLocale();
     return fetchData<CompanyAchievementsResponse>("/company-achievements/", locale);

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -16,6 +16,8 @@ import Header from "@/components/organisms/header";
 const FloatingWhatsapp = dynamic(
     () => import("@/components/atoms/floating-whatsapp")
 );
+import { getCompanyInfo } from "@/api/Company";
+import { getBusinessTypes } from "@/api/BusinessType";
 
 const cannonade = localFont({
     src: [
@@ -67,6 +69,16 @@ export default async function LocaleLayout({ children, params }: Props) {
     }
 
     const messages = await getMessages();
+
+    const [companyInfoResult, businessTypesResult] = await Promise.allSettled([
+        getCompanyInfo(),
+        getBusinessTypes(),
+    ]);
+
+    const companyInfo =
+        companyInfoResult.status === "fulfilled" ? companyInfoResult.value : null;
+    const businessTypes =
+        businessTypesResult.status === "fulfilled" ? businessTypesResult.value : [];
     return (
         <html lang={locale}>
             <head>
@@ -157,7 +169,12 @@ export default async function LocaleLayout({ children, params }: Props) {
                     />
                 </noscript>
                 <NextIntlClientProvider messages={messages}>
-                    <Providers>
+                    <Providers
+                        initialAppData={{
+                            companyInfo,
+                            businessTypes,
+                        }}
+                    >
                         <div className="max-w-[1920px] m-auto relative">
                             <Header />
                             <FloatingWhatsapp />

--- a/src/components/atoms/video-player/index.tsx
+++ b/src/components/atoms/video-player/index.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useEffect, useRef, useState } from "react";
-// import ReactPlayer from "react-player";
 import { VideoLoader } from "../video-loader";
 import dynamic from "next/dynamic";
 
-const ReactPlayer = dynamic(() => import("react-player"), { ssr: false });
+const ReactPlayer = dynamic(() => import("react-player/lazy"), {
+    ssr: false,
+    loading: () => <VideoLoader />,
+});
 
 export const VideoPlayer = ({ video }: { video: string; controls?: boolean }) => {
     const playerRef = useRef<HTMLDivElement>(null);
@@ -49,8 +51,8 @@ export const VideoPlayer = ({ video }: { video: string; controls?: boolean }) =>
         >
             <ReactPlayer
                 url={video}
-                fallback={<VideoLoader />}
                 controls={true}
+                fallback={<VideoLoader />}
                 playing={isVisible && isPlaying}
                 muted={true}
                 // light={true}

--- a/src/components/organisms/video-about-company/index.tsx
+++ b/src/components/organisms/video-about-company/index.tsx
@@ -6,8 +6,13 @@ import React, { useState } from "react";
 import AboutUsSVG from "@/assets/company-info/about_us.svg";
 import MobileAboutUsSVG from "@/assets/company-info/mobile_about_us.svg";
 import { useAppData } from "@/context/app-context";
-import ReactPlayer from "react-player";
+import dynamic from "next/dynamic";
 import { VideoLoader } from "@/components/atoms/video-loader";
+
+const ReactPlayer = dynamic(() => import("react-player/lazy"), {
+    ssr: false,
+    loading: () => <VideoLoader />,
+});
 
 const VideoAboutCompany = () => {
     const { data } = useAppData();

--- a/src/components/organisms/video-about-videoproduction/index.tsx
+++ b/src/components/organisms/video-about-videoproduction/index.tsx
@@ -6,8 +6,13 @@ import React, { useState } from "react";
 import AboutUsSVG from "@/assets/company-info/about_us.svg";
 import MobileAboutUsSVG from "@/assets/company-info/mobile_about_us.svg";
 import { useAppData } from "@/context/app-context";
-import ReactPlayer from "react-player";
+import dynamic from "next/dynamic";
 import { VideoLoader } from "@/components/atoms/video-loader";
+
+const ReactPlayer = dynamic(() => import("react-player/lazy"), {
+    ssr: false,
+    loading: () => <VideoLoader />,
+});
 
 export const VideoCompany = () => {
     const { data } = useAppData();

--- a/src/context/app-context/index.tsx
+++ b/src/context/app-context/index.tsx
@@ -19,9 +19,44 @@ interface AppContextType {
 
 const AppContext = createContext<AppContextType | null>(null)
 
-export const AppContextProvider = ({ children }: { children: React.ReactNode }) => {
-    const { data, isLoading, error } = useGetCompanyInfoQuery()
-    const { data: business_types } = useGetBusinessTypesQuery()
+interface AppContextProviderProps {
+    children: React.ReactNode;
+    initialData?: CompanyInfoResponse | null;
+    initialBusinessTypes?: Type[];
+}
+
+export const AppContextProvider = ({
+    children,
+    initialData = null,
+    initialBusinessTypes = [],
+}: AppContextProviderProps) => {
+    const {
+        data: fetchedData,
+        isLoading: isCompanyLoading,
+        error: companyError,
+    } = useGetCompanyInfoQuery(undefined, {
+        skip: Boolean(initialData),
+    })
+
+    const {
+        data: fetchedBusinessTypes,
+        isLoading: isBusinessTypesLoading,
+        error: businessTypesError,
+    } = useGetBusinessTypesQuery(undefined, {
+        skip: initialBusinessTypes.length > 0,
+    })
+
+    const data = fetchedData ?? initialData ?? null
+    const business_types =
+        fetchedBusinessTypes ??
+        (initialBusinessTypes.length ? initialBusinessTypes : ([] as Type[]))
+
+    const isLoading = Boolean(
+        (!initialData && isCompanyLoading) ||
+            (initialBusinessTypes.length === 0 && isBusinessTypesLoading)
+    )
+
+    const error = companyError ?? businessTypesError ?? null
     const feedbackRef = useRef<HTMLDivElement>(null);
     const reviewRef = useRef<HTMLDivElement>(null);
 

--- a/src/domains/about/index.tsx
+++ b/src/domains/about/index.tsx
@@ -18,11 +18,13 @@ import { RequestHandler } from "@/components/atoms/request-handler";
 export const revalidate = 60;
 
 const AboutPage = async () => {
-    const t = await getTranslations("AboutPage");
-    const data = await getStaticPageBySlug('about');
-    const partners = await getCompanyPartners();
-    const reviews = await getPartnersReviews();
-    const promotion_types = await getPromotionTypes();
+    const [t, data, partners, reviews, promotion_types] = await Promise.all([
+        getTranslations("AboutPage"),
+        getStaticPageBySlug("about"),
+        getCompanyPartners(),
+        getPartnersReviews(),
+        getPromotionTypes(),
+    ]);
 
 
     const names = {

--- a/src/domains/blog/index.tsx
+++ b/src/domains/blog/index.tsx
@@ -12,10 +12,12 @@ import { getPromotionTypes } from "@/api/Types";
 export const revalidate = 60;
 
 const BlogPage = async () => {
-    const data = await getStaticPageBySlug('blog');
-    const t = await getTranslations("AboutPage");
-    const promotion_types = await getPromotionTypes();
-    const articles = await getArticles();
+    const [data, t, promotion_types, articles] = await Promise.all([
+        getStaticPageBySlug("blog"),
+        getTranslations("AboutPage"),
+        getPromotionTypes(),
+        getArticles(),
+    ]);
 
     const names = {
         title: t("banner.title"),

--- a/src/domains/cases/index.tsx
+++ b/src/domains/cases/index.tsx
@@ -15,16 +15,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const CasesPage = async () => {
-    const data = await getStaticPageBySlug('cases');
-    const post_data = await getPosts();
-    const t = await getTranslations("Cases");
-    const promotion_types = await getPromotionTypes();
-    
-    const [partners, reviews] =
-        await Promise.all([
-            getCompanyPartners(),
-            getPartnersReviews()
-        ]);
+    const [
+        data,
+        post_data,
+        t,
+        promotion_types,
+        partners,
+        reviews,
+    ] = await Promise.all([
+        getStaticPageBySlug("cases"),
+        getPosts(),
+        getTranslations("Cases"),
+        getPromotionTypes(),
+        getCompanyPartners(),
+        getPartnersReviews(),
+    ]);
 
     type BannerTexts = {
         title: string;

--- a/src/domains/home/index.tsx
+++ b/src/domains/home/index.tsx
@@ -28,14 +28,25 @@ const NewsBanner = dynamic(() => import("@/components/atoms/NewsBanner/NewsBanne
 export const revalidate = 60;
 
 const HomePage = async () => {
-    const t = await getTranslations("HomePage.section2");
-    const banners = await getBanners();
-    const marketingDepartmentData = await getMarketingDepartment()
-    const companyChallenges = await getCompanyChallenges()
-    const articles = await getArticles()
-    const partners = await getCompanyPartners()
-    const reviews = await getPartnersReviews()
-    const promotion_types = await getPromotionTypes();
+    const [
+        t,
+        banners,
+        marketingDepartmentData,
+        companyChallenges,
+        articles,
+        partners,
+        reviews,
+        promotion_types,
+    ] = await Promise.all([
+        getTranslations("HomePage.section2"),
+        getBanners(),
+        getMarketingDepartment(),
+        getCompanyChallenges(),
+        getArticles(),
+        getCompanyPartners(),
+        getPartnersReviews(),
+        getPromotionTypes(),
+    ]);
     
     return (
         <>

--- a/src/domains/services/branding.tsx
+++ b/src/domains/services/branding.tsx
@@ -25,13 +25,19 @@ import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
 export const revalidate = 60;
 
 const BradingPage = async () => {
-    const data = await getStaticPageBySlug('branding');
-    const t = await getTranslations("ServicePage4");
-    const t2 = await getTranslations("Buttons");
-    const [serviceData, promotion_types] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        serviceData,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("branding"),
+        getTranslations("ServicePage4"),
+        getTranslations("Buttons"),
         getCompanyFeatures(),
-        getPromotionTypes()
-    ])
+        getPromotionTypes(),
+    ]);
 
     const serviceDataStatic = {
         title: "Создаем бренд, который говорит сам за себя",

--- a/src/domains/services/context-ad.tsx
+++ b/src/domains/services/context-ad.tsx
@@ -13,14 +13,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const ContextAdsPage = async () => {
-    const data = await getStaticPageBySlug('context-ads');
-    const [t, t2, contextAdData, contextAdCardData, promotion_types] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        contextAdData,
+        contextAdCardData,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("context-ads"),
         getTranslations("ServicesPage2"),
         getTranslations("Buttons"),
         fetchContextAdData(),
         fetchContextAdCardData(),
         getPromotionTypes(),
-    ])
+    ]);
 
   
 

--- a/src/domains/services/crm.tsx
+++ b/src/domains/services/crm.tsx
@@ -17,9 +17,11 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const CrmPage = async () => {
-    const t = await getTranslations("ServicesPage7")
-    const data = await getStaticPageBySlug('crm')
-    const promotion_types = await getPromotionTypes();
+    const [t, data, promotion_types] = await Promise.all([
+        getTranslations("ServicesPage7"),
+        getStaticPageBySlug("crm"),
+        getPromotionTypes(),
+    ]);
    
     const serviceCrmData: ISmmTeamMembers = {
         title: t("BenefitsSection.title"),

--- a/src/domains/services/marketing-support.tsx
+++ b/src/domains/services/marketing-support.tsx
@@ -18,10 +18,12 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const MarketingSupportPage = async () => {
-    const data = await getStaticPageBySlug("marketing-support");
-    const t = await getTranslations("ServicesPage8");
-    const t2 = await getTranslations("Buttons");
-    const promotion_types = await getPromotionTypes();
+    const [data, t, t2, promotion_types] = await Promise.all([
+        getStaticPageBySlug("marketing-support"),
+        getTranslations("ServicesPage8"),
+        getTranslations("Buttons"),
+        getPromotionTypes(),
+    ]);
     
     const serviceData = {
         title: t("WhatWeDo.mainTitle"),

--- a/src/domains/services/operative-print.tsx
+++ b/src/domains/services/operative-print.tsx
@@ -36,10 +36,12 @@ type Designs = {
 };
 
 const PrintPage = async () => {
-    const data = await getStaticPageBySlug('operative-print');
-    const cards = await getBusinessCards();
-    const t = await getTranslations("ServicesPage9");
-    const promotion_types = await getPromotionTypes();
+    const [data, cards, t, promotion_types] = await Promise.all([
+        getStaticPageBySlug("operative-print"),
+        getBusinessCards(),
+        getTranslations("ServicesPage9"),
+        getPromotionTypes(),
+    ]);
 
     const servicePrintData: ISmmTeamMembers = {
         title: t("howWeWork.title1"),

--- a/src/domains/services/seo.tsx
+++ b/src/domains/services/seo.tsx
@@ -13,15 +13,23 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SeoPage = async () => {
-    const data = await getStaticPageBySlug('seo');
-    const [t, t2, promotion_types, seoData, seoPostsData, seoCardsData] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        promotion_types,
+        seoData,
+        seoPostsData,
+        seoCardsData,
+    ] = await Promise.all([
+        getStaticPageBySlug("seo"),
         getTranslations("ServicesPage3"),
         getTranslations("Buttons"),
         getPromotionTypes(),
         fetchSeoData(),
         fetchSeoPostsData(),
         fetchSeoCardsData(),
-    ])
+    ]);
 
     return (
         <>

--- a/src/domains/services/site-creating.tsx
+++ b/src/domains/services/site-creating.tsx
@@ -10,9 +10,11 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SiteCreatingPage = async () => {
-    const data = await getStaticPageBySlug('site-creating')
-    const promotion_types = await getPromotionTypes();
-    const t = await getTranslations("ServicePage6");
+    const [data, promotion_types, t] = await Promise.all([
+        getStaticPageBySlug("site-creating"),
+        getPromotionTypes(),
+        getTranslations("ServicePage6"),
+    ]);
 
     const serviceData = {
         title: t('Approach.title'),

--- a/src/domains/services/smm.tsx
+++ b/src/domains/services/smm.tsx
@@ -16,12 +16,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SmmPage = async () => {
-    const data = await getStaticPageBySlug('smm');
-    const ads = await getCompanyAds();
-    const t = await getTranslations("ServicesPage1");
-    const smmCreatingAdData = await fetchSmmCreatingAdData();
-    const smmTeamMembers = await fetchSmmTeamMembers();
-    const promotion_types = await getPromotionTypes();
+    const [
+        data,
+        ads,
+        t,
+        smmCreatingAdData,
+        smmTeamMembers,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("smm"),
+        getCompanyAds(),
+        getTranslations("ServicesPage1"),
+        fetchSmmCreatingAdData(),
+        fetchSmmTeamMembers(),
+        getPromotionTypes(),
+    ]);
 
     const serviceData = {
         title: t("zigzak.title"),

--- a/src/domains/services/video-production.tsx
+++ b/src/domains/services/video-production.tsx
@@ -14,10 +14,12 @@ import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
 export const revalidate = 60;
 
 const VideoProductionPage = async () => {
-    const data = await getStaticPageBySlug('video-production');
-    const videoData = await getVideoProduction();
-    const t = await getTranslations("ServicePage5");
-    const promotion_types = await getPromotionTypes();
+    const [data, videoData, t, promotion_types] = await Promise.all([
+        getStaticPageBySlug("video-production"),
+        getVideoProduction(),
+        getTranslations("ServicePage5"),
+        getPromotionTypes(),
+    ]);
 
     const serviceData = {
         title: t("Services.title"),

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -4,11 +4,23 @@ import { FC, PropsWithChildren } from "react"
 import { Toaster } from 'sonner';
 import { StoreProvider } from "./redux-provider";
 import { AppContextProvider } from "@/context/app-context";
+import { CompanyInfoResponse } from "@/api/Company/types";
+import { Type } from "@/api/Types/types";
 
-export const Providers: FC<PropsWithChildren> = ({ children }) => {
+type ProvidersProps = PropsWithChildren<{
+    initialAppData: {
+        companyInfo: CompanyInfoResponse | null;
+        businessTypes: Type[];
+    };
+}>;
+
+export const Providers: FC<ProvidersProps> = ({ children, initialAppData }) => {
     return (
         <StoreProvider>
-            <AppContextProvider>
+            <AppContextProvider
+                initialData={initialAppData.companyInfo}
+                initialBusinessTypes={initialAppData.businessTypes}
+            >
                 <Toaster
                     className="toaster group"
                     richColors
@@ -22,3 +34,4 @@ export const Providers: FC<PropsWithChildren> = ({ children }) => {
 
     )
 }
+


### PR DESCRIPTION
## Summary
- prefetch company info and business type data on the server and hydrate the app context from initial props to avoid extra client requests
- expose locale-aware helpers for company info and business types so layouts can reuse cached fetches
- lazy-load all ReactPlayer instances with dynamic imports and loaders to defer heavy video bundles until interaction

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ecd1784fa0832e888af82e65284bee