### PR TITLE
Share cached API responses, defer heavy widgets, and add resource hints

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,28 @@ const nextConfig: NextConfig = withSvgr({
             },
         ],
     },
+    async headers() {
+        return [
+            {
+                source: "/fonts/:path*",
+                headers: [
+                    {
+                        key: "Cache-Control",
+                        value: "public, max-age=31536000, immutable",
+                    },
+                ],
+            },
+            {
+                source: "/:all*(svg|jpg|jpeg|png|gif|webp|ico)",
+                headers: [
+                    {
+                        key: "Cache-Control",
+                        value: "public, max-age=31536000, immutable",
+                    },
+                ],
+            },
+        ];
+    },
 });
 
 const withNextIntl = createNextIntlPlugin();

--- a/src/api/Base/baseApi.ts
+++ b/src/api/Base/baseApi.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { unstable_cache } from "next/cache"
 
 export const baseUrl = 'https://api.boldbrands.pro/api/v1'
 
@@ -19,28 +20,55 @@ export const baseApi = createApi({
     tagTypes: []
 })
 
+async function requestData<T>(endpoint: string, locale: string, cache: RequestCache) {
+    try {
+        const shouldShareCache = cache === "force-cache" || cache === "default"
+        let nextOptions: { revalidate: number; tags: string[] } | undefined
+
+        if (shouldShareCache) {
+            nextOptions = {
+                revalidate: 3600,
+                tags: [`api:${endpoint}`],
+            }
+        }
+
+        const response = await fetch(`${baseUrl}${endpoint}`, {
+            cache,
+            headers: {
+                "Accept-Language": locale,
+            },
+            next: nextOptions,
+        })
+
+        if (!response.ok) {
+            console.error("Ошибка загрузки:", response.status, response.statusText)
+            throw new Error(`Failed to fetch ${endpoint}`)
+        }
+
+        return (await response.json()) as T
+    } catch (error) {
+        console.error(`Ошибка в ${endpoint}:`, error)
+        throw error
+    }
+}
+
+const cachedRequestData = unstable_cache(
+    async (endpoint: string, locale: string, cache: RequestCache) =>
+        requestData(endpoint, locale, cache),
+    ["fetchData"],
+    { revalidate: 3600 }
+)
+
 export async function fetchData<T>(
     endpoint: string,
     locale: string = 'ru',
     cache: RequestCache = "force-cache"
 ): Promise<T> {
-    try {
-        const res = await fetch(`${baseUrl}${endpoint}`, {
-            next: { revalidate: 60 },
-            cache,
-            headers: {
-                "Accept-Language": locale
-            }
-        })
+    const shouldShareCache = cache === "force-cache" || cache === "default"
 
-        if (!res.ok) {
-            console.error("Ошибка загрузки:", res.status, res.statusText)
-            throw new Error(`Failed to fetch ${endpoint}`)
-        }
-
-        return res.json()
-    } catch (error) {
-        console.error(`Ошибка в ${endpoint}:`, error)
-        throw error
+    if (!shouldShareCache) {
+        return requestData<T>(endpoint, locale, cache)
     }
+
+    return cachedRequestData(endpoint, locale, cache) as Promise<T>
 }

--- a/src/api/BusinessType/index.ts
+++ b/src/api/BusinessType/index.ts
@@ -24,3 +24,8 @@ export async function getBusinessCards() {
     const locale = await getLocale()
     return fetchData<ParallaxData>("/business-cards/", locale)
 }
+
+export async function getBusinessTypes(cache: RequestCache = "force-cache") {
+    const locale = await getLocale()
+    return fetchData<Type[]>("/business-types/", locale, cache)
+}

--- a/src/api/Company/index.ts
+++ b/src/api/Company/index.ts
@@ -1,5 +1,5 @@
 import { baseApi } from "../Base";
-import { baseUrl, fetchData } from "../Base/baseApi";
+import { fetchData } from "../Base/baseApi";
 import {
     CompanyAchievementsResponse,
     CompanyAdvertisingResponse,
@@ -65,25 +65,17 @@ export const {
 
 export async function getVideoReviews(cache: RequestCache = "force-cache") {
     const locale = await getLocale();
-
-    const res = await fetch(`${baseUrl}/company-video-reviews/`, {
-        cache,
-        headers: {
-            "Accept-Language": locale,
-        },
-    });
-
-    if (!res.ok) {
-        console.error(`Ошибка загрузки баннеров: ${res.status} ${res.statusText}`);
-        throw new Error("Failed to fetch home page data");
-    }
-
-    return res.json();
+    return fetchData<CompanyVideoReviewsResponse>("/company-video-reviews/", locale, cache);
 }
 
 export async function getCompanyChallenges() {
     const locale = await getLocale();
     return fetchData<CompanyChallengesResponse>("/company-challenges/", locale);
+}
+
+export async function getCompanyInfo(cache: RequestCache = "force-cache") {
+    const locale = await getLocale();
+    return fetchData<CompanyInfoResponse>("/company-info/", locale, cache);
 }
 
 export async function getCompanyAdvantages() {

--- a/src/app/[locale]/contacts/page.tsx
+++ b/src/app/[locale]/contacts/page.tsx
@@ -1,8 +1,19 @@
-import FormLayout from "@/components/templates/form-layout";
-import { Map } from "./Map";
+import dynamic from "next/dynamic";
 import { Metadata } from "next";
-import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
+
 import { getPromotionTypes } from "@/api/Types";
+import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
+import FormLayout from "@/components/templates/form-layout";
+import { LazyHydrate } from "@/components/utils/lazy-hydrate";
+
+const Map = dynamic(() => import("./Map").then((mod) => mod.Map), {
+    ssr: false,
+    loading: () => (
+        <div className="flex h-[60vh] items-center justify-center rounded-[32px] bg-background-dark text-lg font-semibold">
+            Загрузка карты...
+        </div>
+    ),
+});
 
 export const metadata: Metadata = {
     title: "Контакты",
@@ -18,9 +29,11 @@ const ContactsPage = async () => {
                 title={'Получите бесплатную консультацию'}
                 nestedForm={<CostCalculationForm promotion_types={promotion_types} />}
             />
-            <Map/>
+            <LazyHydrate rootMargin="600px">
+                <Map />
+            </LazyHydrate>
         </>
     );
 }
- 
+
 export default ContactsPage;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -16,6 +16,8 @@ import Header from "@/components/organisms/header";
 const FloatingWhatsapp = dynamic(
     () => import("@/components/atoms/floating-whatsapp")
 );
+import { getCompanyInfo } from "@/api/Company";
+import { getBusinessTypes } from "@/api/BusinessType";
 
 const cannonade = localFont({
     src: [
@@ -30,6 +32,7 @@ const cannonade = localFont({
             style: "normal",
         },
     ],
+    display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -67,9 +70,27 @@ export default async function LocaleLayout({ children, params }: Props) {
     }
 
     const messages = await getMessages();
+
+    const [companyInfoResult, businessTypesResult] = await Promise.allSettled([
+        getCompanyInfo(),
+        getBusinessTypes(),
+    ]);
+
+    const companyInfo =
+        companyInfoResult.status === "fulfilled" ? companyInfoResult.value : null;
+    const businessTypes =
+        businessTypesResult.status === "fulfilled" ? businessTypesResult.value : [];
     return (
         <html lang={locale}>
             <head>
+                <link rel="dns-prefetch" href="https://api.boldbrands.pro" />
+                <link rel="preconnect" href="https://api.boldbrands.pro" crossOrigin="anonymous" />
+                <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+                <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
+                <link rel="dns-prefetch" href="https://mc.yandex.ru" />
+                <link rel="preconnect" href="https://mc.yandex.ru" crossOrigin="anonymous" />
+                <link rel="dns-prefetch" href="https://connect.facebook.net" />
+                <link rel="preconnect" href="https://connect.facebook.net" crossOrigin="anonymous" />
                 <Script id="gtm-init" strategy="afterInteractive">
                     {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TWLSLSMG');`}
                 </Script>
@@ -157,7 +178,12 @@ export default async function LocaleLayout({ children, params }: Props) {
                     />
                 </noscript>
                 <NextIntlClientProvider messages={messages}>
-                    <Providers>
+                    <Providers
+                        initialAppData={{
+                            companyInfo,
+                            businessTypes,
+                        }}
+                    >
                         <div className="max-w-[1920px] m-auto relative">
                             <Header />
                             <FloatingWhatsapp />

--- a/src/components/atoms/video-player/index.tsx
+++ b/src/components/atoms/video-player/index.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useEffect, useRef, useState } from "react";
-// import ReactPlayer from "react-player";
 import { VideoLoader } from "../video-loader";
 import dynamic from "next/dynamic";
 
-const ReactPlayer = dynamic(() => import("react-player"), { ssr: false });
+const ReactPlayer = dynamic(() => import("react-player/lazy"), {
+    ssr: false,
+    loading: () => <VideoLoader />,
+});
 
 export const VideoPlayer = ({ video }: { video: string; controls?: boolean }) => {
     const playerRef = useRef<HTMLDivElement>(null);
@@ -49,8 +51,8 @@ export const VideoPlayer = ({ video }: { video: string; controls?: boolean }) =>
         >
             <ReactPlayer
                 url={video}
-                fallback={<VideoLoader />}
                 controls={true}
+                fallback={<VideoLoader />}
                 playing={isVisible && isPlaying}
                 muted={true}
                 // light={true}

--- a/src/components/organisms/parallax/index.tsx
+++ b/src/components/organisms/parallax/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import Image from "next/image";
 import { ParallaxData } from "@/api/BusinessType/types";
-import { ParallaxProps } from "@/domains/services/operative-print";
 import React, { useEffect, useRef } from "react";
 
 export const ParallaxSection: React.FC<ParallaxData> = ({
@@ -64,24 +64,27 @@ export const ParallaxSection: React.FC<ParallaxData> = ({
                 "linear-gradient(0deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.4) 100%)",
                         }}
                     ></div>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
+                    <Image
                         ref={(el) => {
                             imgRefs.current[index] = el;
                         }}
                         src={item.image}
                         alt={`Parallax Speed`}
                         data-speed={item.speed || 1}
+                        fill
+                        priority={index === 0}
+                        loading={index === 0 ? "eager" : "lazy"}
+                        sizes="100vw"
                         className="
-              absolute 
-              top-0 
-              left-1/2 
+              absolute
+              top-0
+              left-1/2
               -translate-x-1/2
-              pointer-events-none 
+              pointer-events-none
               object-cover
-              w-auto 
-              h-auto 
-              min-w-full 
+              w-auto
+              h-auto
+              min-w-full
               min-h-full
             "
                         style={{ transform: "translate(-50%, 0)" }}

--- a/src/components/organisms/video-about-company/index.tsx
+++ b/src/components/organisms/video-about-company/index.tsx
@@ -6,8 +6,13 @@ import React, { useState } from "react";
 import AboutUsSVG from "@/assets/company-info/about_us.svg";
 import MobileAboutUsSVG from "@/assets/company-info/mobile_about_us.svg";
 import { useAppData } from "@/context/app-context";
-import ReactPlayer from "react-player";
+import dynamic from "next/dynamic";
 import { VideoLoader } from "@/components/atoms/video-loader";
+
+const ReactPlayer = dynamic(() => import("react-player/lazy"), {
+    ssr: false,
+    loading: () => <VideoLoader />,
+});
 
 const VideoAboutCompany = () => {
     const { data } = useAppData();

--- a/src/components/organisms/video-about-videoproduction/index.tsx
+++ b/src/components/organisms/video-about-videoproduction/index.tsx
@@ -6,8 +6,13 @@ import React, { useState } from "react";
 import AboutUsSVG from "@/assets/company-info/about_us.svg";
 import MobileAboutUsSVG from "@/assets/company-info/mobile_about_us.svg";
 import { useAppData } from "@/context/app-context";
-import ReactPlayer from "react-player";
+import dynamic from "next/dynamic";
 import { VideoLoader } from "@/components/atoms/video-loader";
+
+const ReactPlayer = dynamic(() => import("react-player/lazy"), {
+    ssr: false,
+    loading: () => <VideoLoader />,
+});
 
 export const VideoCompany = () => {
     const { data } = useAppData();

--- a/src/components/utils/lazy-hydrate.tsx
+++ b/src/components/utils/lazy-hydrate.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+    PropsWithChildren,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
+
+export type LazyHydrateProps = PropsWithChildren<{
+    /**
+     * Distance in pixels before the component enters the viewport
+     * and starts hydrating.
+     */
+    rootMargin?: string;
+    /**
+     * Re-render every time the element becomes visible.
+     */
+    once?: boolean;
+}>;
+
+export const LazyHydrate = ({
+    children,
+    rootMargin = "300px",
+    once = true,
+}: LazyHydrateProps) => {
+    const [shouldRender, setShouldRender] = useState(false);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (shouldRender) {
+            return;
+        }
+
+        const node = containerRef.current;
+
+        if (!node) {
+            return;
+        }
+
+        if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+            setShouldRender(true);
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        setShouldRender(true);
+                        if (once) {
+                            observer.disconnect();
+                        }
+                    }
+                });
+            },
+            { rootMargin },
+        );
+
+        observer.observe(node);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [once, rootMargin, shouldRender]);
+
+    return <div ref={containerRef}>{shouldRender ? children : null}</div>;
+};

--- a/src/context/app-context/index.tsx
+++ b/src/context/app-context/index.tsx
@@ -19,9 +19,44 @@ interface AppContextType {
 
 const AppContext = createContext<AppContextType | null>(null)
 
-export const AppContextProvider = ({ children }: { children: React.ReactNode }) => {
-    const { data, isLoading, error } = useGetCompanyInfoQuery()
-    const { data: business_types } = useGetBusinessTypesQuery()
+interface AppContextProviderProps {
+    children: React.ReactNode;
+    initialData?: CompanyInfoResponse | null;
+    initialBusinessTypes?: Type[];
+}
+
+export const AppContextProvider = ({
+    children,
+    initialData = null,
+    initialBusinessTypes = [],
+}: AppContextProviderProps) => {
+    const {
+        data: fetchedData,
+        isLoading: isCompanyLoading,
+        error: companyError,
+    } = useGetCompanyInfoQuery(undefined, {
+        skip: Boolean(initialData),
+    })
+
+    const {
+        data: fetchedBusinessTypes,
+        isLoading: isBusinessTypesLoading,
+        error: businessTypesError,
+    } = useGetBusinessTypesQuery(undefined, {
+        skip: initialBusinessTypes.length > 0,
+    })
+
+    const data = fetchedData ?? initialData ?? null
+    const business_types =
+        fetchedBusinessTypes ??
+        (initialBusinessTypes.length ? initialBusinessTypes : ([] as Type[]))
+
+    const isLoading = Boolean(
+        (!initialData && isCompanyLoading) ||
+            (initialBusinessTypes.length === 0 && isBusinessTypesLoading)
+    )
+
+    const error = companyError ?? businessTypesError ?? null
     const feedbackRef = useRef<HTMLDivElement>(null);
     const reviewRef = useRef<HTMLDivElement>(null);
 

--- a/src/domains/about/index.tsx
+++ b/src/domains/about/index.tsx
@@ -18,11 +18,13 @@ import { RequestHandler } from "@/components/atoms/request-handler";
 export const revalidate = 60;
 
 const AboutPage = async () => {
-    const t = await getTranslations("AboutPage");
-    const data = await getStaticPageBySlug('about');
-    const partners = await getCompanyPartners();
-    const reviews = await getPartnersReviews();
-    const promotion_types = await getPromotionTypes();
+    const [t, data, partners, reviews, promotion_types] = await Promise.all([
+        getTranslations("AboutPage"),
+        getStaticPageBySlug("about"),
+        getCompanyPartners(),
+        getPartnersReviews(),
+        getPromotionTypes(),
+    ]);
 
 
     const names = {

--- a/src/domains/blog/index.tsx
+++ b/src/domains/blog/index.tsx
@@ -12,10 +12,12 @@ import { getPromotionTypes } from "@/api/Types";
 export const revalidate = 60;
 
 const BlogPage = async () => {
-    const data = await getStaticPageBySlug('blog');
-    const t = await getTranslations("AboutPage");
-    const promotion_types = await getPromotionTypes();
-    const articles = await getArticles();
+    const [data, t, promotion_types, articles] = await Promise.all([
+        getStaticPageBySlug("blog"),
+        getTranslations("AboutPage"),
+        getPromotionTypes(),
+        getArticles(),
+    ]);
 
     const names = {
         title: t("banner.title"),

--- a/src/domains/cases/index.tsx
+++ b/src/domains/cases/index.tsx
@@ -15,16 +15,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const CasesPage = async () => {
-    const data = await getStaticPageBySlug('cases');
-    const post_data = await getPosts();
-    const t = await getTranslations("Cases");
-    const promotion_types = await getPromotionTypes();
-    
-    const [partners, reviews] =
-        await Promise.all([
-            getCompanyPartners(),
-            getPartnersReviews()
-        ]);
+    const [
+        data,
+        post_data,
+        t,
+        promotion_types,
+        partners,
+        reviews,
+    ] = await Promise.all([
+        getStaticPageBySlug("cases"),
+        getPosts(),
+        getTranslations("Cases"),
+        getPromotionTypes(),
+        getCompanyPartners(),
+        getPartnersReviews(),
+    ]);
 
     type BannerTexts = {
         title: string;

--- a/src/domains/home/index.tsx
+++ b/src/domains/home/index.tsx
@@ -28,14 +28,25 @@ const NewsBanner = dynamic(() => import("@/components/atoms/NewsBanner/NewsBanne
 export const revalidate = 60;
 
 const HomePage = async () => {
-    const t = await getTranslations("HomePage.section2");
-    const banners = await getBanners();
-    const marketingDepartmentData = await getMarketingDepartment()
-    const companyChallenges = await getCompanyChallenges()
-    const articles = await getArticles()
-    const partners = await getCompanyPartners()
-    const reviews = await getPartnersReviews()
-    const promotion_types = await getPromotionTypes();
+    const [
+        t,
+        banners,
+        marketingDepartmentData,
+        companyChallenges,
+        articles,
+        partners,
+        reviews,
+        promotion_types,
+    ] = await Promise.all([
+        getTranslations("HomePage.section2"),
+        getBanners(),
+        getMarketingDepartment(),
+        getCompanyChallenges(),
+        getArticles(),
+        getCompanyPartners(),
+        getPartnersReviews(),
+        getPromotionTypes(),
+    ]);
     
     return (
         <>

--- a/src/domains/services/branding.tsx
+++ b/src/domains/services/branding.tsx
@@ -25,13 +25,19 @@ import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
 export const revalidate = 60;
 
 const BradingPage = async () => {
-    const data = await getStaticPageBySlug('branding');
-    const t = await getTranslations("ServicePage4");
-    const t2 = await getTranslations("Buttons");
-    const [serviceData, promotion_types] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        serviceData,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("branding"),
+        getTranslations("ServicePage4"),
+        getTranslations("Buttons"),
         getCompanyFeatures(),
-        getPromotionTypes()
-    ])
+        getPromotionTypes(),
+    ]);
 
     const serviceDataStatic = {
         title: "Создаем бренд, который говорит сам за себя",

--- a/src/domains/services/context-ad.tsx
+++ b/src/domains/services/context-ad.tsx
@@ -13,14 +13,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const ContextAdsPage = async () => {
-    const data = await getStaticPageBySlug('context-ads');
-    const [t, t2, contextAdData, contextAdCardData, promotion_types] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        contextAdData,
+        contextAdCardData,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("context-ads"),
         getTranslations("ServicesPage2"),
         getTranslations("Buttons"),
         fetchContextAdData(),
         fetchContextAdCardData(),
         getPromotionTypes(),
-    ])
+    ]);
 
   
 

--- a/src/domains/services/crm.tsx
+++ b/src/domains/services/crm.tsx
@@ -17,9 +17,11 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const CrmPage = async () => {
-    const t = await getTranslations("ServicesPage7")
-    const data = await getStaticPageBySlug('crm')
-    const promotion_types = await getPromotionTypes();
+    const [t, data, promotion_types] = await Promise.all([
+        getTranslations("ServicesPage7"),
+        getStaticPageBySlug("crm"),
+        getPromotionTypes(),
+    ]);
    
     const serviceCrmData: ISmmTeamMembers = {
         title: t("BenefitsSection.title"),

--- a/src/domains/services/marketing-support.tsx
+++ b/src/domains/services/marketing-support.tsx
@@ -18,10 +18,12 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const MarketingSupportPage = async () => {
-    const data = await getStaticPageBySlug("marketing-support");
-    const t = await getTranslations("ServicesPage8");
-    const t2 = await getTranslations("Buttons");
-    const promotion_types = await getPromotionTypes();
+    const [data, t, t2, promotion_types] = await Promise.all([
+        getStaticPageBySlug("marketing-support"),
+        getTranslations("ServicesPage8"),
+        getTranslations("Buttons"),
+        getPromotionTypes(),
+    ]);
     
     const serviceData = {
         title: t("WhatWeDo.mainTitle"),

--- a/src/domains/services/operative-print.tsx
+++ b/src/domains/services/operative-print.tsx
@@ -36,10 +36,12 @@ type Designs = {
 };
 
 const PrintPage = async () => {
-    const data = await getStaticPageBySlug('operative-print');
-    const cards = await getBusinessCards();
-    const t = await getTranslations("ServicesPage9");
-    const promotion_types = await getPromotionTypes();
+    const [data, cards, t, promotion_types] = await Promise.all([
+        getStaticPageBySlug("operative-print"),
+        getBusinessCards(),
+        getTranslations("ServicesPage9"),
+        getPromotionTypes(),
+    ]);
 
     const servicePrintData: ISmmTeamMembers = {
         title: t("howWeWork.title1"),

--- a/src/domains/services/seo.tsx
+++ b/src/domains/services/seo.tsx
@@ -13,15 +13,23 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SeoPage = async () => {
-    const data = await getStaticPageBySlug('seo');
-    const [t, t2, promotion_types, seoData, seoPostsData, seoCardsData] = await Promise.all([
+    const [
+        data,
+        t,
+        t2,
+        promotion_types,
+        seoData,
+        seoPostsData,
+        seoCardsData,
+    ] = await Promise.all([
+        getStaticPageBySlug("seo"),
         getTranslations("ServicesPage3"),
         getTranslations("Buttons"),
         getPromotionTypes(),
         fetchSeoData(),
         fetchSeoPostsData(),
         fetchSeoCardsData(),
-    ])
+    ]);
 
     return (
         <>

--- a/src/domains/services/site-creating.tsx
+++ b/src/domains/services/site-creating.tsx
@@ -10,9 +10,11 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SiteCreatingPage = async () => {
-    const data = await getStaticPageBySlug('site-creating')
-    const promotion_types = await getPromotionTypes();
-    const t = await getTranslations("ServicePage6");
+    const [data, promotion_types, t] = await Promise.all([
+        getStaticPageBySlug("site-creating"),
+        getPromotionTypes(),
+        getTranslations("ServicePage6"),
+    ]);
 
     const serviceData = {
         title: t('Approach.title'),

--- a/src/domains/services/smm.tsx
+++ b/src/domains/services/smm.tsx
@@ -16,12 +16,21 @@ import { getTranslations } from "next-intl/server";
 export const revalidate = 60;
 
 const SmmPage = async () => {
-    const data = await getStaticPageBySlug('smm');
-    const ads = await getCompanyAds();
-    const t = await getTranslations("ServicesPage1");
-    const smmCreatingAdData = await fetchSmmCreatingAdData();
-    const smmTeamMembers = await fetchSmmTeamMembers();
-    const promotion_types = await getPromotionTypes();
+    const [
+        data,
+        ads,
+        t,
+        smmCreatingAdData,
+        smmTeamMembers,
+        promotion_types,
+    ] = await Promise.all([
+        getStaticPageBySlug("smm"),
+        getCompanyAds(),
+        getTranslations("ServicesPage1"),
+        fetchSmmCreatingAdData(),
+        fetchSmmTeamMembers(),
+        getPromotionTypes(),
+    ]);
 
     const serviceData = {
         title: t("zigzak.title"),

--- a/src/domains/services/video-production.tsx
+++ b/src/domains/services/video-production.tsx
@@ -14,10 +14,12 @@ import { CostCalculationForm } from "@/components/forms/cost-calculation-form";
 export const revalidate = 60;
 
 const VideoProductionPage = async () => {
-    const data = await getStaticPageBySlug('video-production');
-    const videoData = await getVideoProduction();
-    const t = await getTranslations("ServicePage5");
-    const promotion_types = await getPromotionTypes();
+    const [data, videoData, t, promotion_types] = await Promise.all([
+        getStaticPageBySlug("video-production"),
+        getVideoProduction(),
+        getTranslations("ServicePage5"),
+        getPromotionTypes(),
+    ]);
 
     const serviceData = {
         title: t("Services.title"),

--- a/src/providers/client-toaster.tsx
+++ b/src/providers/client-toaster.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Toaster } from "sonner";
+
+const ClientToaster = () => {
+    return (
+        <Toaster
+            className="toaster group"
+            richColors
+            position="top-center"
+            duration={3000}
+            visibleToasts={3}
+        />
+    );
+};
+
+export default ClientToaster;

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -1,24 +1,35 @@
 "use client";
 
-import { FC, PropsWithChildren } from "react"
-import { Toaster } from 'sonner';
-import { StoreProvider } from "./redux-provider";
-import { AppContextProvider } from "@/context/app-context";
+import dynamic from "next/dynamic";
+import { FC, PropsWithChildren } from "react";
 
-export const Providers: FC<PropsWithChildren> = ({ children }) => {
+import { CompanyInfoResponse } from "@/api/Company/types";
+import { Type } from "@/api/Types/types";
+import { AppContextProvider } from "@/context/app-context";
+import { StoreProvider } from "./redux-provider";
+
+const ClientToaster = dynamic(() => import("./client-toaster"), {
+    ssr: false,
+});
+
+type ProvidersProps = PropsWithChildren<{
+    initialAppData: {
+        companyInfo: CompanyInfoResponse | null;
+        businessTypes: Type[];
+    };
+}>;
+
+export const Providers: FC<ProvidersProps> = ({ children, initialAppData }) => {
     return (
         <StoreProvider>
-            <AppContextProvider>
-                <Toaster
-                    className="toaster group"
-                    richColors
-                    position="top-center"
-                    duration={3000}
-                    visibleToasts={3}
-                />
+            <AppContextProvider
+                initialData={initialAppData.companyInfo}
+                initialBusinessTypes={initialAppData.businessTypes}
+            >
+                <ClientToaster />
                 {children}
             </AppContextProvider>
         </StoreProvider>
+    );
+};
 
-    )
-}


### PR DESCRIPTION
## Summary
- wrap the shared fetchData helper in an unstable_cache layer so server components reuse API responses while still respecting revalidation
- reuse the cached fetchData utility for company video reviews to avoid bespoke network requests and benefit from shared caching
- add dns-prefetch and preconnect hints for analytics and API domains to reduce connection setup time during initial page loads
- convert the parallax hero imagery to the Next.js Image component so large backgrounds stream efficiently and load lazily
- lazy-load the Google Map and toast UI to hydrate only after they enter the viewport and shrink the main JavaScript bundle
- set long-lived cache headers for static assets and stretch API revalidation windows to cut duplicate network work

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ecd1784fa0832e888af82e65284bee